### PR TITLE
Changes to AMD SMI Exporter to support exporting new GPU metric - GPU…

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,11 @@ PROC_HOT status of the processor has been triggered.
 	### Type: Gauge
 	### Property: Read-only
 
+## 17. amd_gpu_Usage
+        ### Description: Displays the GPU Use percent
+        ### Type: Gauge
+        ### Property: Read-only
+
 <a name="custom"></a>
 ## Custom rules
 

--- a/src/collect/cpustat.go
+++ b/src/collect/cpustat.go
@@ -58,6 +58,7 @@ type AMDParams struct {
 	GPUTemperature [24]float64
 	GPUSCLK [24]float64
 	GPUMCLK [24]float64
+	GPUUsage [24]float64
 }
 
 func Scan() (AMDParams) {
@@ -133,6 +134,10 @@ func Scan() (AMDParams) {
 			value64 = uint64(goamdsmi.GO_rsmi_dev_gpu_clk_freq_get_mclk(i))
 			stat.GPUMCLK[i] = float64(value64)
 			value64 = 0
+
+                        value64 = uint64(goamdsmi.GO_rsmi_dev_gpu_busy_percent_get(i))
+                        stat.GPUUsage[i] = float64(value64)
+                        value64 = 0
 		}
 	}
 

--- a/src/cpu_data.go
+++ b/src/cpu_data.go
@@ -65,6 +65,7 @@ type amd_data struct {
 	GPUTemperature *prometheus.Desc
 	GPUSCLK *prometheus.Desc
 	GPUMCLK *prometheus.Desc
+	GPUUsage *prometheus.Desc
 	Data func() (collect.AMDParams)
 }
 
@@ -172,6 +173,13 @@ func NewCollector(handle func() (collect.AMDParams)) prometheus.Collector {
 			[]string{"gpu_MCLK"},// The metric's variable label dimensions.
 			nil,// The metric's constant label dimensions.
 		),
+		GPUUsage: prometheus.NewDesc(
+                        prometheus.BuildFQName("amd", "", "gpu_use_percent"),
+                        "AMD Params",// The metric's help text.
+                        []string{"gpu_use_percent"},// The metric's variable label dimensions.
+                        nil,// The metric's constant label dimensions.
+                ),
+
 
 		Data: handle, //This is the Scan() function handle
 	}
@@ -287,6 +295,15 @@ func (c *amd_data) Collect(ch chan<- prometheus.Metric) {
 		ch <- prometheus.MustNewConstMetric(c.GPUMCLK,
 			prometheus.GaugeValue, float64(s), strconv.Itoa(i))
 	}
+
+        for i,s := range data.GPUUsage{
+                if uint(i) > (data.NumGPUs - 1) {
+                        continue
+                }
+                ch <- prometheus.MustNewConstMetric(c.GPUUsage,
+                        prometheus.GaugeValue, float64(s), strconv.Itoa(i))
+        }
+
 
 	ch <- prometheus.MustNewConstMetric(c.Sockets,
 		prometheus.GaugeValue, float64(data.Sockets), "")


### PR DESCRIPTION
… use percent - to prometheus

Adding support to query GPU use percentage from ROCm-smi lib.

Required changes to "go_amd_smi"  have been done and are in PR https://github.com/amd/go_amd_smi/pull/1