### PR TITLE
Changes to provide go binding for ROCm-smi to query GPU Memory usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,11 @@ PROC_HOT status of the processor has been triggered.
         ### Type: Gauge
         ### Property: Read-only
 
+## 18. amd_gpu_memory_busy percent
+        ### Description: Displays the GPU Memory busy percent
+        ### Type: Gauge
+        ### Property: Read-only
+
 <a name="custom"></a>
 ## Custom rules
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -4,7 +4,7 @@ build:
 	go get github.com/prometheus/client_golang
 	go get github.com/prometheus/client_golang/prometheus
 	go get github.com/prometheus/client_golang/prometheus/promhttp
-	go get github.com/amd/go_amd_smi
+	go get github.com/amd/go_amd_smi@master
 	go build -o amd_smi_exporter main.go cpu_data.go
 
 clean:

--- a/src/collect/cpustat.go
+++ b/src/collect/cpustat.go
@@ -59,6 +59,7 @@ type AMDParams struct {
 	GPUSCLK [24]float64
 	GPUMCLK [24]float64
 	GPUUsage [24]float64
+	GPUMemoryUsage [24]float64
 }
 
 func Scan() (AMDParams) {
@@ -138,6 +139,11 @@ func Scan() (AMDParams) {
                         value64 = uint64(goamdsmi.GO_rsmi_dev_gpu_busy_percent_get(i))
                         stat.GPUUsage[i] = float64(value64)
                         value64 = 0
+
+			value64 = uint64(goamdsmi.GO_rsmi_dev_gpu_memory_busy_percent_get(i))
+                        stat.GPUMemoryUsage[i] = float64(value64)
+                        value64 = 0
+
 		}
 	}
 

--- a/src/cpu_data.go
+++ b/src/cpu_data.go
@@ -66,6 +66,7 @@ type amd_data struct {
 	GPUSCLK *prometheus.Desc
 	GPUMCLK *prometheus.Desc
 	GPUUsage *prometheus.Desc
+	GPUMemoryUsage *prometheus.Desc
 	Data func() (collect.AMDParams)
 }
 
@@ -177,6 +178,12 @@ func NewCollector(handle func() (collect.AMDParams)) prometheus.Collector {
                         prometheus.BuildFQName("amd", "", "gpu_use_percent"),
                         "AMD Params",// The metric's help text.
                         []string{"gpu_use_percent"},// The metric's variable label dimensions.
+                        nil,// The metric's constant label dimensions.
+                ),
+                GPUMemoryUsage: prometheus.NewDesc(
+                        prometheus.BuildFQName("amd", "", "gpu_memory_use_percent"),
+                        "AMD Params",// The metric's help text.
+                        []string{"gpu_memory_use_percent"},// The metric's variable label dimensions.
                         nil,// The metric's constant label dimensions.
                 ),
 
@@ -304,6 +311,13 @@ func (c *amd_data) Collect(ch chan<- prometheus.Metric) {
                         prometheus.GaugeValue, float64(s), strconv.Itoa(i))
         }
 
+        for i,s := range data.GPUMemoryUsage{
+                if uint(i) > (data.NumGPUs - 1) {
+                        continue
+                }
+                ch <- prometheus.MustNewConstMetric(c.GPUMemoryUsage,
+                        prometheus.GaugeValue, float64(s), strconv.Itoa(i))
+        }
 
 	ch <- prometheus.MustNewConstMetric(c.Sockets,
 		prometheus.GaugeValue, float64(data.Sockets), "")

--- a/src/k8/daemonset.yaml
+++ b/src/k8/daemonset.yaml
@@ -19,6 +19,10 @@ spec:
       - name: amd-smi-exporter-container
         image: "amd_smi_exporter_container:0.1"
         imagePullPolicy: Never
+        securityContext:
+          privileged: true #Needed for /dev
+          capabilities:
+            drop: ["ALL"]
         ports:
         - containerPort: 2021
         args:


### PR DESCRIPTION
Adding support to amd_smi_exporter for exposing GPU memory use percent metric to Prometheus.