### PR TITLE
Increase array bounds for MultiSocket systems

### DIFF
--- a/src/collect/cpustat.go
+++ b/src/collect/cpustat.go
@@ -43,11 +43,11 @@ import "github.com/amd/go_amd_smi"
 
 type AMDParams struct {
 	CoreEnergy [512]float64
-	SocketEnergy [2]float64
+	SocketEnergy [4]float64
 	CoreBoost [512]float64
-	SocketPower [2]float64
-	PowerLimit [2]float64
-	ProchotStatus [2]float64
+	SocketPower [4]float64
+	PowerLimit [4]float64
+	ProchotStatus [4]float64
 	Sockets uint
 	Threads uint
 	ThreadsPerCore uint


### PR DESCRIPTION
Observed "panic: runtime error: index out of range" when try to fetch the query from prometheus served. So the below change increases array bounds for MultiSocket systems example more than 2 sockets.

Issue observed below:

user@pp-128-a4-4:~/Goamdsmi/amd_smi_exporter/src$ ./amd_smi_exporter 2024/04/30 06:28:01 starting collector exporter on ":9090" panic: runtime error: index out of range [2] with length 2

goroutine 50 [running]:
src/collect.Scan()
        amd_smi_exporter/src/collect/cpustat.go:93 +0x61a
main.main.func1()
        amd_smi_exporter/src/main.go:107 +0x34
main.(*amd_data).Collect(0xc0003c6000, 0xc0002940c0)
        amd_smi_exporter/src/cpu_data.go:208 +0x42
github.com/prometheus/client_golang/prometheus.(*Registry).Gather.func1()
        /go/pkg/mod/github.com/prometheus/client_golang@v1.19.0/prometheus/registry.go:455 +0x105
created by github.com/prometheus/client_golang/prometheus.(*Registry).Gather in goroutine 23
        /go/pkg/mod/github.com/prometheus/client_golang@v1.19.0/prometheus/registry.go:547 +0xbab
user@pp-128-a4-4:~/amd_smi_exporter/src$ client_loop: send disconnect: Broken pipe